### PR TITLE
[YWH-41] Fix command/script injection via file-list step outputs in action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -351,6 +351,10 @@ runs:
         POLL_MAX_WAIT: "${{ inputs.poll_max_wait }}"
         SKIP_DEFAULT_FLAGS: "${{ inputs.skip_default_flags }}"
         PLATFORM: "${{ steps.detect-platform.outputs.platform }}"
+        # File lists are attacker-influenceable (translation file names). Pass them
+        # through env so bash treats them as data, never as inline script. See YWH-41.
+        ALL_FILES: "${{ steps.find-files.outputs.ALL_FILES }}"
+        CHANGED_FILES: "${{ steps.changed-files.outputs.all_changed_files }}"
       run: |
         set -euo pipefail
 
@@ -358,9 +362,9 @@ runs:
 
         if [ "${{ inputs.rambo_mode }}" == "true" ] || \
           ( [ "${{ steps.changed-files.outputs.any_changed }}" != "true" ] && [ "${{ steps.check-first-run.outputs.first_run }}" == "true" ] ); then
-          FILES="${{ steps.find-files.outputs.ALL_FILES }}"
+          FILES="$ALL_FILES"
         else
-          FILES="${{ steps.changed-files.outputs.all_changed_files }}"
+          FILES="$CHANGED_FILES"
         fi
 
         if [ -z "$FILES" ]; then


### PR DESCRIPTION
## Summary

Fixes a GitHub Actions **script injection** (CWE-77/78) in the composite `action.yml`, reported via the Lokalise VDP program.

Report: https://yeswehack.com/vulnerability-center/reports/822950

The "Push translation files to Lokalise" step built its `FILES` variable by inlining two step outputs directly into the `run:` block via `${{ … }}` expansion:

```yaml
FILES="${{ steps.find-files.outputs.ALL_FILES }}"          # sink A (rambo / first-run path)
...
FILES="${{ steps.changed-files.outputs.all_changed_files }}" # sink B (normal diff path)
```

Both outputs are **lists of discovered translation file names**, which are attacker-influenceable content, not trusted config.

## Why this was exploitable

`${{ … }}` expansion happens at workflow-**compile** time, *before* bash executes — the substituted string becomes part of the script source. A translation file whose name contains shell metacharacters therefore breaks out of the string literal and executes as commands on the runner. The downstream `printf '%s' "$FILES" | tr ',' '\n' | xargs …` is correctly quoted, but that runs *after* the break-out has already occurred, so it provides no protection.

Data flow confirmed in this repo:

- `src/find_all_files/collect.go` → `fileCollector.add()` only applies `filepath.ToSlash` + dedup — **no metacharacter filtering**.
- `src/find_all_files/process.go` → `strings.Join(allFiles, ",")` → `writeOutput("ALL_FILES", …)`.
- The output writer (`lokalise-actions-common/v2/githuboutput`) rejects only `\r`/`\n`, so quotes, `$`, `;`, backticks, spaces all pass into `$GITHUB_OUTPUT`.
- `action.yml` then inlined that value into the `run:` script (sink A). Sink B is the parallel `tj-actions/changed-files` path.

A payload such as `locales/en/a";id;".json` is a valid Linux filename (only `/` and NUL are disallowed) and ends in an accepted extension, so it survives collection and reaches the sink.

**Impact:** arbitrary code execution on the Actions runner with the step's `LOKALISE_API_TOKEN` and the job's `GITHUB_TOKEN` in scope. The worst-case "unauthenticated fork contributor" chain additionally requires a consumer to wire the action into `pull_request_target` (a plain `pull_request` from a fork gets no secrets and a read-only token); regardless of trigger, anyone able to land a maliciously-named file on a branch that runs the workflow can trigger it. Cheap to fix either way.

The tell that this was an oversight: every other value in the same step is already passed safely via `env:` and referenced as `"$VAR"` — only the two file-lists were inlined.

## Fix

Route both file-lists through the step's `env:` block and reference them as quoted shell variables, consistent with every sibling value:

```yaml
env:
  ...
  ALL_FILES: "${{ steps.find-files.outputs.ALL_FILES }}"
  CHANGED_FILES: "${{ steps.changed-files.outputs.all_changed_files }}"
run: |
  ...
  FILES="$ALL_FILES"      # was inlined ${{ }}
  ...
  FILES="$CHANGED_FILES"  # was inlined ${{ }}
```

Env-var expansion happens inside bash at runtime, where the value is treated as plain data and never re-parsed as script. The existing `printf … | tr … | xargs` pipeline already handles the values safely once they are in a variable.

## Follow-up (not in this PR)

Defense-in-depth suggested by the reporter, tracked separately:
- Reject/encode file names containing shell metacharacters at the Go collection layer.
- Move from comma-joined lists to NUL-delimited (`git diff -z` / `xargs -0`) to also handle names containing commas or newlines robustly.

## Testing

- Change is limited to `action.yml` string handling; no Go behavior changed.
- Existing binaries/tests unaffected.

- [x] **Yes, AI assisted with this PR**